### PR TITLE
Make genwords.py python3-compatible; a minor fix

### DIFF
--- a/genwords.py
+++ b/genwords.py
@@ -13,7 +13,7 @@ with open(dictfile) as file:
     wordlist = [w for w in file.read().split()]
 
 random.shuffle(wordlist)
-wordlist = filter(lambda w: all(c in printable for c in w), wordlist)
+wordlist = list(filter(lambda w: all(c in printable for c in w), wordlist))
 wordlist = wordlist[:1300]
 
 for word in wordlist:


### PR DESCRIPTION
Just a small fix, really. But an essential one, nevertheless, esp. with the approaching [Python2 EOL](https://pythonclock.org/).